### PR TITLE
feat: 회원정보 조회 API에 최근 로그인 및 가입일시 필드 추가

### DIFF
--- a/src/main/java/com/com2here/com2hereback/dto/UserShowRespDto.java
+++ b/src/main/java/com/com2here/com2hereback/dto/UserShowRespDto.java
@@ -1,6 +1,9 @@
 package com.com2here.com2hereback.dto;
 
+import java.time.LocalDateTime;
+
 import com.com2here.com2hereback.domain.User;
+
 import lombok.Builder;
 import lombok.Data;
 
@@ -13,6 +16,8 @@ public class UserShowRespDto {
     private String profileImageUrl;
     private boolean isVerified;
     private String role;
+    private LocalDateTime createdAt;
+    private LocalDateTime lastLoginAt;
 
     public static UserShowRespDto entityToDto(User user){
         return UserShowRespDto.builder()
@@ -22,6 +27,8 @@ public class UserShowRespDto {
             .profileImageUrl(user.getProfileImageUrl())
             .isVerified(user.isEmailVerified())
             .role(user.getRole().name())
+            .createdAt(user.getCreatedAt())
+            .lastLoginAt(user.getLastLoginAt())
             .build();
     }
 }

--- a/src/main/java/com/com2here/com2hereback/vo/UserShowVO.java
+++ b/src/main/java/com/com2here/com2hereback/vo/UserShowVO.java
@@ -1,5 +1,7 @@
 package com.com2here.com2hereback.vo;
 
+import java.time.LocalDateTime;
+
 import com.com2here.com2hereback.dto.UserShowRespDto;
 import lombok.Value;
 
@@ -11,6 +13,8 @@ public class UserShowVO {
     String profileImageUrl;
     boolean isVerified;
     String role;
+    LocalDateTime createdAt;
+    LocalDateTime lastLoginAt;
 
     public static UserShowVO from(UserShowRespDto dto) {
         return new UserShowVO(
@@ -19,7 +23,9 @@ public class UserShowVO {
             dto.getEmail(),
             dto.getProfileImageUrl(),
             dto.isVerified(),
-            dto.getRole()
+            dto.getRole(),
+            dto.getCreatedAt(),
+            dto.getLastLoginAt()
         );
     }
 }


### PR DESCRIPTION
- User 엔티티에서 lastLoginAt, createdAt 조회 가능하도록 수정
- UserShowRespDto 및 UserShowVO에 신규 필드 매핑
- 관리자 회원정보 조회 응답에 최근 로그인 일시와 가입일시 반환