### PR TITLE
feat: (관리자)회원정보 수정 API에 이메일 인증 여부 필드 추가

### DIFF
--- a/src/main/java/com/com2here/com2hereback/dto/AdminUserUpdateReqDto.java
+++ b/src/main/java/com/com2here/com2hereback/dto/AdminUserUpdateReqDto.java
@@ -10,11 +10,9 @@ import com.com2here.com2hereback.common.Role;
 public class AdminUserUpdateReqDto {
 
     private String nickname;
-
     @Email(message = "유효한 이메일 주소여야 합니다.")
     private String email;
-
     private Role role;
-
+    private Boolean isEmailVerified;
     private MultipartFile profileImage;
 }

--- a/src/main/java/com/com2here/com2hereback/service/AdminUserServiceImpl.java
+++ b/src/main/java/com/com2here/com2hereback/service/AdminUserServiceImpl.java
@@ -18,8 +18,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -72,6 +70,10 @@ public class AdminUserServiceImpl implements AdminUserService {
             updatedImageUrl = fileStorageService.upload(updateDto.getProfileImage());
         }
 
+        Boolean updatedIsEmailVerified = updateDto.getIsEmailVerified() != null 
+                ? updateDto.getIsEmailVerified() 
+                : user.isEmailVerified();
+
         User updatedUser = User.builder()
                 .userId(user.getUserId())
                 .uuid(user.getUuid())
@@ -79,7 +81,7 @@ public class AdminUserServiceImpl implements AdminUserService {
                 .email(updateDto.getEmail() != null ? updateDto.getEmail() : user.getEmail())
                 .password(user.getPassword())
                 .role(updateDto.getRole() != null ? updateDto.getRole() : user.getRole())
-                .isEmailVerified(user.isEmailVerified())
+                .isEmailVerified(updatedIsEmailVerified)
                 .profileImageUrl(updatedImageUrl)
                 .refreshToken(user.getRefreshToken())
                 .createdAt(user.getCreatedAt())
@@ -88,6 +90,7 @@ public class AdminUserServiceImpl implements AdminUserService {
 
         userRepository.save(updatedUser);
     }
+
 
     @Override
     @Transactional


### PR DESCRIPTION
- AdminUserUpdateReqDto에 isEmailVerified 필드 추가
- 관리자 회원정보 수정 시 이메일 인증 상태 업데이트 가능하도록 구현