### PR TITLE
feat: 관심 상품 해제 API 구현

### DIFF
--- a/src/main/java/com/com2here/com2hereback/common/BaseResponseStatus.java
+++ b/src/main/java/com/com2here/com2hereback/common/BaseResponseStatus.java
@@ -131,7 +131,8 @@ public enum BaseResponseStatus {
     // Oauth
     INVALID_PROVIDER(HttpStatus.BAD_REQUEST, false, 2400, "존재하지 않는 제공자입니다."),
     INVALID_URI(HttpStatus.BAD_REQUEST, false, 2400, "유효하지 않은 URI입니다."),
-    JSON_PARSE_ERROR(HttpStatus.BAD_REQUEST, false, 2401, "JSON 파싱 중 오류가 발생했습니다.");
+    JSON_PARSE_ERROR(HttpStatus.BAD_REQUEST, false, 2401, "JSON 파싱 중 오류가 발생했습니다."),
+    NO_EXIST_WISH(HttpStatus.NOT_FOUND, false, 2701, "해당 관심 상품이 존재하지 않습니다.");
 
 
 

--- a/src/main/java/com/com2here/com2hereback/controller/ProductController.java
+++ b/src/main/java/com/com2here/com2hereback/controller/ProductController.java
@@ -9,6 +9,8 @@ import com.com2here.com2hereback.vo.ProductListVO;
 import com.com2here.com2hereback.vo.ProductShowVO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -53,5 +55,11 @@ public class ProductController {
         ProductListRespDto productListRespDto =  productService.wishlistProduct(page, limit);
         ProductListVO productListVo = ProductListVO.from(productListRespDto);
         return CMResponse.success(BaseResponseStatus.SUCCESS, productListVo);
+    }
+
+    @DeleteMapping("/wish/delete/{wish_id}")
+    public CMResponse<Void> deleteWishProduct(@PathVariable("wish_id") Long wishId) {
+        productService.deleteWishProduct(wishId);
+        return CMResponse.success(BaseResponseStatus.SUCCESS);
     }
 }

--- a/src/main/java/com/com2here/com2hereback/service/ProductService.java
+++ b/src/main/java/com/com2here/com2hereback/service/ProductService.java
@@ -8,4 +8,5 @@ public interface ProductService {
     ProductShowRespDto showProduct(Long productId);
     ProductListRespDto listProduct (int page, int limit);
     ProductListRespDto wishlistProduct (int page, int limit);
+    void deleteWishProduct(Long productId);
 }

--- a/src/main/java/com/com2here/com2hereback/service/ProductServiceImpl.java
+++ b/src/main/java/com/com2here/com2hereback/service/ProductServiceImpl.java
@@ -121,4 +121,26 @@ public class ProductServiceImpl implements ProductService {
 
         return productListResponseDto;
     }
+
+    @Override
+    @Transactional
+    public void deleteWishProduct(Long wishId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String uuid = (String) authentication.getPrincipal();
+
+        User user = userRepository.findByUuid(uuid);
+        if (user == null) {
+            throw new BaseException(BaseResponseStatus.NO_EXIST_MEMBERS);
+        }
+
+        Wishlist wishlist = wishlistRepository.findById(wishId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NO_EXIST_WISH));
+
+        if (!wishlist.getUser().equals(user)) {
+            throw new BaseException(BaseResponseStatus.NO_EXIST_WISH);
+        }
+
+        wishlistRepository.delete(wishlist);
+    }
+
 }


### PR DESCRIPTION
- 관심 상품 해제 엔드포인트 추가 (DELETE /api/v1/product/wish/delete/{wish_id})
- JWT 인증 기반 본인 관심 상품만 해제 가능하도록 로직 작성
- DB에서 사용자-상품 매핑 관계 삭제 기능 구현