### PR TITLE
fix: Program 조회 시 minSpec, recSpec null 반환 및 purpose 매핑 오류 해결

### DIFF
--- a/src/main/java/com/com2here/com2hereback/common/ProgramPurpose.java
+++ b/src/main/java/com/com2here/com2hereback/common/ProgramPurpose.java
@@ -1,18 +1,29 @@
 package com.com2here.com2hereback.common;
 
+import lombok.Getter;
+
+@Getter
 public enum ProgramPurpose {
-    게임용,
-    작업용,
-    사무용,
-    개발용;
+    GAME("게임용"),
+    WORK("작업용"),
+    OFFICE("사무용"),
+    DEV("개발용");
+
+    private final String displayName;
+
+    ProgramPurpose(String displayName) {
+        this.displayName = displayName;
+    }
 
     public static ProgramPurpose from(String input) {
-        if (input == null) return null;
+        if (input == null || input.isBlank()) return null;
+
         for (ProgramPurpose purpose : ProgramPurpose.values()) {
-            if (purpose.name().equals(input.trim())) {
+            if (purpose.name().equalsIgnoreCase(input.trim()) || 
+                purpose.displayName.equals(input.trim())) {
                 return purpose;
             }
         }
-        return null;
+        throw new IllegalArgumentException("유효하지 않은 ProgramPurpose 값: " + input);
     }
 }

--- a/src/main/java/com/com2here/com2hereback/domain/Program.java
+++ b/src/main/java/com/com2here/com2hereback/domain/Program.java
@@ -20,7 +20,7 @@ public class Program {
     private String program;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "purpose", nullable = false)
+    @Column(name = "purpose", nullable = false, length = 20)
     private ProgramPurpose purpose;
 
     @Column(name = "spec_level", nullable = false)

--- a/src/main/java/com/com2here/com2hereback/repository/ProgramRepository.java
+++ b/src/main/java/com/com2here/com2hereback/repository/ProgramRepository.java
@@ -4,6 +4,7 @@ import com.com2here.com2hereback.domain.Program;
 import com.com2here.com2hereback.common.ProgramPurpose;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,15 +13,15 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProgramRepository extends JpaRepository<Program, Long> {
 
-    // Optional<Program> findByMainProgramIgnoreCaseAndPurpose(String mainProgram, ProgramPurpose purpose);
-
+    @EntityGraph(attributePaths = {"rSpec", "mSpec"})
     @Query("""
         select p
         from Program p
-        where (:search is null or p.program like %:search%)
+        where (:search is null or lower(p.program) like lower(concat('%', :search, '%')))
         and (:purpose is null or p.purpose = :purpose)
     """)
     Page<Program> findPage(@Param("search") String search,
-        @Param("purpose") ProgramPurpose purpose,
-        Pageable pageable);
+                        @Param("purpose") ProgramPurpose purpose,
+                        Pageable pageable);
+
 }

--- a/src/main/java/com/com2here/com2hereback/service/ProgramServiceImpl.java
+++ b/src/main/java/com/com2here/com2hereback/service/ProgramServiceImpl.java
@@ -9,10 +9,11 @@ import com.com2here.com2hereback.domain.ProgramRSpec;
 import com.com2here.com2hereback.dto.ProgramUpdateReqDto;
 import com.com2here.com2hereback.dto.ProgramAddReqDto;
 import com.com2here.com2hereback.dto.ProgramDeleteReqDto;
-import com.com2here.com2hereback.dto.ProgramRespDto;
 import com.com2here.com2hereback.repository.ProgramMSpecRepository;
 import com.com2here.com2hereback.repository.ProgramRSpecRepository;
 import com.com2here.com2hereback.repository.ProgramRepository;
+import com.com2here.com2hereback.vo.ProgramVO;
+
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,7 +22,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -73,26 +73,27 @@ public class ProgramServiceImpl implements ProgramService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<String, Object> getProgram(int page, int limit, String search, String purpose) {
-        Pageable pageable = PageRequest.of(page - 1, limit, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(page - 1, limit);
 
-        ProgramPurpose programPurpose = null;
+        ProgramPurpose enumPurpose = null;
         if (purpose != null && !purpose.isBlank()) {
-            programPurpose = ProgramPurpose.valueOf(purpose);
+            enumPurpose = ProgramPurpose.from(purpose);
         }
 
-        Page<Program> pageResult = programRepository.findPage(search, programPurpose, pageable);
-        Page<ProgramRespDto> dtoPage = pageResult.map(ProgramRespDto::new);
+        Page<Program> programs = programRepository.findPage(search, enumPurpose, pageable);
+        Page<ProgramVO> programVOs = programs.map(ProgramVO::from);
 
-        Map<String, Object> result = new HashMap<>();
-        result.put("content", dtoPage.getContent());
-        result.put("totalElements", dtoPage.getTotalElements());
-        result.put("totalPages", dtoPage.getTotalPages());
-        result.put("pageNumber", dtoPage.getNumber() + 1); // 사용자 기준 1부터 시작하게 다시 +1
-        result.put("pageSize", dtoPage.getSize());
-        result.put("isLast", dtoPage.isLast());
+        Map<String, Object> response = new HashMap<>();
+        response.put("pageNumber", programVOs.getNumber() + 1);
+        response.put("isLast", programVOs.isLast());
+        response.put("totalPages", programVOs.getTotalPages());
+        response.put("pageSize", programVOs.getSize());
+        response.put("content", programVOs.getContent());
+        response.put("totalElements", programVOs.getTotalElements());
 
-        return result;
+        return response;
     }
 
     @Override

--- a/src/main/java/com/com2here/com2hereback/vo/ProgramVO.java
+++ b/src/main/java/com/com2here/com2hereback/vo/ProgramVO.java
@@ -3,14 +3,13 @@ package com.com2here.com2hereback.vo;
 import lombok.Value;
 import java.time.LocalDateTime;
 
-import com.com2here.com2hereback.common.ProgramPurpose;
 import com.com2here.com2hereback.domain.Program;
 
 @Value
 public class ProgramVO {
     Long id;
     String name;
-    ProgramPurpose purpose;
+    String purpose;
     String specLevel;
     SpecVO recSpec;
     SpecVO minSpec;
@@ -21,7 +20,7 @@ public class ProgramVO {
         return new ProgramVO(
             program.getProgramId(),
             program.getProgram(),
-            program.getPurpose(),
+            program.getPurpose().getDisplayName(),
             program.getSpecLevel(),
             new SpecVO(
                 program.getRSpec().getCpu(),


### PR DESCRIPTION
- ProgramService#getProgram에서 purpose 문자열 → ProgramPurpose enum 변환 추가
- programRepository.findPage에 @EntityGraph(attributePaths = {"rSpec", "mSpec"}) 적용하여 Lazy Loading 문제 해결
- ProgramVO 변환 시 SpecVO null-safe 처리 보완
- /program/show API 응답에서 minSpec, recSpec 정상 반환 및 필터링 동작 확인